### PR TITLE
Added layout support and footer component

### DIFF
--- a/components/layouts/MainLayout.tsx
+++ b/components/layouts/MainLayout.tsx
@@ -1,0 +1,15 @@
+import AppBar from "../molecules/AppBar";
+import AppFooter from "../molecules/AppFooter";
+import { LayoutProps } from "./pageWithLayoutType";
+
+const MainLayout: LayoutProps = ({ children }) => {
+  return (
+    <>
+      <AppBar />
+      <div>{children}</div>
+      <AppFooter />
+    </>
+  )
+}
+
+export default MainLayout

--- a/components/layouts/PageWithLayoutType.tsx
+++ b/components/layouts/PageWithLayoutType.tsx
@@ -1,0 +1,10 @@
+import { NextPage } from "next";
+import MainLayout from "./MainLayout";
+
+export type PageWithMainLayoutType = NextPage & { layout: typeof MainLayout }
+
+export type PageWithLayoutType = | PageWithMainLayoutType
+
+export type LayoutProps = ({children}: {children: JSX.Element}) => JSX.Element
+
+export default PageWithLayoutType

--- a/components/molecules/AppFooter.tsx
+++ b/components/molecules/AppFooter.tsx
@@ -1,0 +1,38 @@
+import { FC } from "react";
+import { FaDiscord, FaSpotify, FaTwitter } from "react-icons/fa";
+
+const AppFooter: FC = () => {
+  const data = [
+    { name: "Home", link: "#" },
+    { name: "Blog", link: "#" },
+    { name: "Terms of Service", link: "#" },
+    { name: "Tools", link: "#" },
+    { name: "Discount", link: "#" },
+    { name: "Privacy Policy", link: "#" }
+  ]
+
+  return (
+    <>
+      <div className="flex flex-col md:flex-row flex-wrap bg-[#343038] py-10">
+        {data.map((item, index) =>
+          <div className="p-2 text-white text-center text-lg md:text-sm md:w-1/3" key={index}>
+            <span className="cursor-pointer">{item.name}</span>
+          </div>
+        )}
+        <div className="pt-5 text-white text-sm text-center md:text-left md:text-sm md:w-1/3">
+          <span className="pl-2">Brought to you by the Web 3 Academy DAO</span>
+        </div>
+        <div className="pt-5 text-white flex flex-row justify-center gap-10 md:w-1/3">
+          <FaDiscord className="w-8 h-8 cursor-pointer" />
+          <FaTwitter className="w-8 h-8 cursor-pointer" />
+          <FaSpotify className="w-8 h-8 cursor-pointer" />
+        </div>
+        <div className="pt-5 text-white text-sm text-center md:text-right md:text-sm md:w-1/3">
+          <span className="pr-2">Brought to you by the Web 3 Academy DAO</span>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default AppFooter;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,14 +4,24 @@ import { ThemeProvider } from "next-themes";
 import { Provider } from "react-redux";
 import { defaultStore, storeWrapper } from '../../components/services/Store'
 import NetworkClient from '../../components/services/NetworkClient';
+import PageWithLayoutType from '../../components/layouts/pageWithLayoutType';
 
 NetworkClient.setup(defaultStore)
 
-function MyApp({ Component, pageProps }: AppProps) {
+type AppLayoutPros = AppProps & {
+  Component: PageWithLayoutType,
+  pageProps: any
+}
+
+function MyApp({ Component, pageProps }: AppLayoutPros) {
+  const Layout = Component.layout || ((children: JSX.Element) => <>{children}</>)
+
   return (
     <Provider store={defaultStore}>
       <ThemeProvider attribute="class">
-        <Component {...pageProps} />
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
       </ThemeProvider>
     </Provider>
   );

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -1,13 +1,12 @@
 import Image from "next/image";
 import { useState } from "react";
-import Rocket from "../../public/rocket.svg";
-import { SelectControl, SelectOption } from "../../components/molecules/SelectControl";
-import AppBar from "../../components/molecules/AppBar";
-import { BadgeBar } from "../../components/molecules/BadgeBar";
 import { BadgeItemData } from "../../components/atoms/BadgeItem";
 import { CardItemData } from "../../components/atoms/CardItem";
+import MainLayout from "../../components/layouts/MainLayout";
+import { BadgeBar } from "../../components/molecules/BadgeBar";
 import { CardGrid } from "../../components/molecules/CardGrid";
-
+import { SelectControl, SelectOption } from "../../components/molecules/SelectControl";
+import Rocket from "../../public/rocket.svg";
 
 const Landing = () => {
   const cardItems: CardItemData[] = [
@@ -42,7 +41,6 @@ const Landing = () => {
 
   return (
     <>
-      <AppBar />
       <section className="relative">
         <div className="container flex flex-col-reverse md:flex-row items-center gap-12 mt-14 md:mt-16">
           <div className="flex flex-col items-center md:items-start md:ml-[10%] md:basis-8/12">
@@ -92,5 +90,7 @@ const Landing = () => {
     </>
   )
 }
+
+Landing.layout = MainLayout
 
 export default Landing;


### PR DESCRIPTION
Currently there is one layout called `MainLayout`. In the future, we can add more layouts, i.e guest layout, seo landing layout...etc.
The layout should be persistent and the common components should not be redrawn on nav changes.

The following files are added/changed:

- Added layout file (MainLayout.tsx)
- Added layout type support file (PageWithLayoutType.tsx)
- Added footer component (AppFooter.tsx)
- Updated landing page to use layout